### PR TITLE
top/right/bottom/left direction set relative to device orientation @W…

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,18 @@ export const App = () => {
   menuParent.style.visibility = 'hidden';
   document.body.appendChild(menuParent);
 
+  // let debugText = 'default';
+
+  // const debugDisplay = document.createElement('div');
+  // debugDisplay.style.position = 'absolute';
+  // debugDisplay.style.width = '100vw';
+  // debugDisplay.style.height = '60px';
+  // debugDisplay.style.marginTop = '20px'
+  // debugDisplay.style.backgroundColor = 'lightgray';
+  // debugDisplay.innerHTML = debugText;
+
+  //document.body.appendChild(debugDisplay);
+
   // SCENE SETUP
   const scene = Scene();
   const camera = Camera();
@@ -36,9 +48,6 @@ export const App = () => {
   let hitTestManager;
 
   let hitTestActive = true;
-  // ROBOT
- // const robot = Robot();
- // scene.addToScene(robot.getMesh());
   // SOLDIER
   const soldier = Soldier(() => {
     const actionMenu = ActionMenu({ 
@@ -47,7 +56,8 @@ export const App = () => {
       setClipAction: soldier.setClipAction });
     const directionMenu = DirectionMenu({
       menuParent,
-      setDirection: soldier.setDirection
+      setDirection: soldier.setDirection,
+      camera
     })
   });
   scene.addToScene(soldier.mesh);
@@ -67,9 +77,6 @@ export const App = () => {
     if (reticle.visible) {
       const workingPositionVec3 = new THREE.Vector3();
       workingPositionVec3.setFromMatrixPosition(reticle.matrix);
-      //scene.addBox({ positionVec3: workingPositionVec3 });
-    //  robot.visible = true;
-     // robot.setMatrixFromArray(workingPositionVec3);
       soldier.setMatrixFromArray(workingPositionVec3);
       hitTestActive = false;
       reticle.visible = false;
@@ -92,7 +99,6 @@ export const App = () => {
         }
       }
       reticle.updateMixer(dt);
-  //  robot.updateMixer(dt);
     soldier.update(dt);
     renderer.render(scene.obj, camera.obj);
   }

--- a/src/components/ActionMenu/index.js
+++ b/src/components/ActionMenu/index.js
@@ -5,7 +5,7 @@ export const ActionMenu = ({
   setClipAction }) => {
 
   const flexContainer = document.createElement('div');
-    flexContainer.style.position = 'absolute';
+  flexContainer.style.position = 'absolute';
   flexContainer.style.display = 'flex';
   flexContainer.style.justifyContent = 'space-around';
   flexContainer.style.width = '100vw';

--- a/src/components/DirectionMenu/index.js
+++ b/src/components/DirectionMenu/index.js
@@ -1,8 +1,9 @@
-import { NaiveBroadphase } from "cannon-es";
+
 
 export const DirectionMenu = ({ 
   menuParent, 
-  setDirection }) => {
+  setDirection,
+  camera }) => {
 
   const flexContainer = document.createElement('div');
   flexContainer.style.display = 'inline';
@@ -34,7 +35,27 @@ export const DirectionMenu = ({
   }
 
   function onClick ({ label }) {
-    setDirection(label);
+    const [x, yNow, z, w] = camera.obj.quaternion.toArray();
+
+    // if (yNow !== yPrev) {
+       const angle = 2 * Math.acos(w);
+       let s;
+       if (1 - w * w < 0.000001) {
+         s = 1;
+       } else {
+         s = Math.sqrt(1 - w * w);
+       }
+       //const result = { axis: new THREE.Vector3(x/s, yNow/s, z/s), angle }
+       const cameraYradians = yNow/s * angle;
+       const yAngle = { 
+          TOP: cameraYradians,
+          RIGHT: cameraYradians - Math.PI/2,
+          BOTTOM: cameraYradians + Math.PI,
+          LEFT: cameraYradians + Math.PI/2
+       }
+
+       console.log('new Direction', yAngle[label] )
+    setDirection(yAngle[label] );
   }
 
 

--- a/src/components/Renderer/index.js
+++ b/src/components/Renderer/index.js
@@ -13,5 +13,7 @@ export function Renderer() {
     setAnimationLoop: renderer.setAnimationLoop,
     render: (scene, camera) => renderer.render(scene, camera),
     get obj() { return renderer },
+    getCamera: renderer.xr.getCamera,
+    getReferenceSpace: renderer.xr.getReferenceSpace
   }
 }

--- a/src/components/Soldier/index.js
+++ b/src/components/Soldier/index.js
@@ -32,7 +32,7 @@ export function Soldier(onLoadCallback) {
   let xDirection;
   let zDirection;
   let speed = .028;
-  setDirection('TOP');
+  setDirection(0);
 
   gltfLoader.load('/models/Soldier.glb', (gltf) => {
     gltf.scene.scale.set(.125, .125, .125);
@@ -72,8 +72,8 @@ export function Soldier(onLoadCallback) {
     }
   }
   // SET DIRECTION
-  function setDirection (newDirection) {
-    targetRadians = DIRECTION[newDirection];
+  function setDirection (radians) {
+    targetRadians = radians; //DIRECTION[newDirection];
     yRotateQuaternion.setFromAxisAngle(yRotateAngle, targetRadians);
   }
   // SET POSITION TO HIT TEST RESULTS

--- a/src/components/XRManager/index.js
+++ b/src/components/XRManager/index.js
@@ -48,6 +48,7 @@ export function XRManager({
     if (onSelectCallback !== undefined) onSelectCallback(ev);
   }
 
+
   return {
     get obj() { return xrSession },
     get xrSession() { return xrSession},


### PR DESCRIPTION
Tapping the TOP, RIGHT, BOTTOM, or LEFT UI elements sets the y rotation of the mesh relative to the current camera quaternion. In this way, UP is always away from the user, BOTTOM is towards, and LEFT/RIGHT correspond the user's own left/right. This allows the user to follow the walking/running animation around while retaining the ability to intuitively guide it.