### PR TITLE
move rotation methods to modular component @WXR-014

### DIFF
--- a/src/components/Rotation/index.js
+++ b/src/components/Rotation/index.js
@@ -1,0 +1,46 @@
+
+import * as THREE from 'three';
+
+export const Rotation = ({ 
+  mesh, 
+  turningIncrement,
+  defaultRotation }) => {
+  let xMagnitude;
+  let zMagnitude;
+  let yPrev;
+  let targetRadians = defaultRotation;
+  const yRotateAngle = new THREE.Vector3(0, 1, 0);
+  const yRotateQuaternion = new THREE.Quaternion();
+  yRotateQuaternion.setFromAxisAngle(yRotateAngle, targetRadians)
+  
+  function setDirection (radians) {
+    targetRadians = radians;
+    yRotateQuaternion.setFromAxisAngle(yRotateAngle, targetRadians)
+  }
+
+  function update () {
+      mesh.quaternion.rotateTowards(yRotateQuaternion, turningIncrement);
+      const [x, yNow, z, w] = mesh.quaternion.toArray();
+      if (yNow !== yPrev) {
+        const angle = 2 * Math.acos(w);
+        let s;
+        if (1 - w * w < 0.000001) {
+          s = 1;
+        } else {
+          s = Math.sqrt(1 - w * w);
+        }
+        const yAngle = yNow/s * angle;
+        xMagnitude = Math.sin(-yAngle);
+        zMagnitude = Math.cos(yAngle);
+        yPrev = yNow;
+      }
+    }
+  
+
+  return {
+    setDirection,
+    update,
+    get xMagnitude() { return xMagnitude },
+    get zMagnitude() { return zMagnitude }
+  }
+}


### PR DESCRIPTION
Moved rotation methods out of main loop and into a modular component. The Rotation component updates the mesh each frame via _mesh.quaternion.rotateTowards_ and sets the corresponding x and z magnitudes for the translation update. 

```
export const Rotation = ({ 
  mesh, 
  turningIncrement,
  defaultRotation }) => {

 ...

  return {
    setDirection,
    update,
    get xMagnitude() { return xMagnitude },
    get zMagnitude() { return zMagnitude }
  }
}
```